### PR TITLE
「のみ」「だけ」の重複を避ける

### DIFF
--- a/src/components/services.js
+++ b/src/components/services.js
@@ -39,7 +39,7 @@ export default function Services() {
           </ul>
           <MyCard
             title="ブロックチェーン開発"
-            content="Ethereumベースのトークン（ERC721等）の開発を行っております。またブロックチェーンのみの開発だけではなく、UI等含めたアプリケーションを含めて開発可能です。"
+            content="Ethereumベースのトークン（ERC721等）の開発を行っております。またブロックチェーン開発だけではなく、UI等含めたアプリケーションを含めて開発可能です。"
           />
           <MyCard
             title="Webシステム開発"


### PR DESCRIPTION
Serviceページでの日本語の限定詞、「のみ」「だけ」の重複を避けるのはどうでしょうか。

old:
またブロックチェーンのみの開発だけではなく、UI等含めたアプリケーションを含めて開発可能です。

proposal:
またブロックチェーン開発だけではなく、UI等含めたアプリケーションを含めて開発可能です。